### PR TITLE
Export camera poses JSON with mobile mesh

### DIFF
--- a/app/android/jni/RTABMapApp.cpp
+++ b/app/android/jni/RTABMapApp.cpp
@@ -3381,47 +3381,6 @@ bool RTABMapApp::exportMesh(
 
         bool success = false;
 
-        std::map<int, rtabmap::Transform> cameraPoses;
-        std::map<int, double> cameraStamps;
-        if(rtabmap_ && rtabmap_->getMemory())
-        {
-                std::map<int, rtabmap::Transform> poses = rtabmap_->getLocalOptimizedPoses();
-                if(poses.empty())
-                {
-                        std::multimap<int, rtabmap::Link> tmpLinks;
-                        rtabmap_->getGraph(poses, tmpLinks, true, true);
-                }
-                for(std::map<int, rtabmap::Transform>::const_iterator iter=poses.lower_bound(0); iter!=poses.end(); ++iter)
-                {
-                        cameraPoses.insert(*iter);
-                        rtabmap::Transform odomPose, groundTruth;
-                        int mapId = 0;
-                        int weight = 0;
-                        std::string label;
-                        double stamp = 0.0;
-                        std::vector<float> velocity;
-                        rtabmap::GPS gps;
-                        rtabmap::EnvSensors sensors;
-                        bool infoFound = rtabmap_->getMemory()->getNodeInfo(
-                                        iter->first,
-                                        odomPose,
-                                        mapId,
-                                        weight,
-                                        label,
-                                        stamp,
-                                        groundTruth,
-                                        velocity,
-                                        gps,
-                                        sensors,
-                                        true);
-                        if(!infoFound)
-                        {
-                                UWARN("Failed to get node info for pose %d when exporting camera positions.", iter->first);
-                        }
-                        cameraStamps.insert(std::make_pair(iter->first, stamp));
-                }
-        }
-
 	try
 	{
 		int totalSteps = 0;
@@ -4457,13 +4416,51 @@ bool RTABMapApp::writeExportedMesh(const std::string & directory, const std::str
 		}
         }
 
-        if(!cameraPoses.empty())
+        if(success && rtabmap_ && rtabmap_->getMemory())
         {
+                std::map<int, rtabmap::Transform> cameraPoses;
+                std::map<int, double> cameraStamps;
+                std::map<int, rtabmap::Transform> stampedPoses = rtabmap_->getLocalOptimizedPoses();
+                if(stampedPoses.empty())
+                {
+                        std::multimap<int, rtabmap::Link> tmpLinks;
+                        rtabmap_->getGraph(stampedPoses, tmpLinks, true, true);
+                }
+                for(std::map<int, rtabmap::Transform>::const_iterator iter=stampedPoses.lower_bound(0); iter!=stampedPoses.end(); ++iter)
+                {
+                        cameraPoses.insert(*iter);
+                        rtabmap::Transform odomPose, groundTruth;
+                        int mapId = 0;
+                        int weight = 0;
+                        std::string label;
+                        double stamp = 0.0;
+                        std::vector<float> velocity;
+                        rtabmap::GPS gps;
+                        rtabmap::EnvSensors sensors;
+                        bool infoFound = rtabmap_->getMemory()->getNodeInfo(
+                                        iter->first,
+                                        odomPose,
+                                        mapId,
+                                        weight,
+                                        label,
+                                        stamp,
+                                        groundTruth,
+                                        velocity,
+                                        gps,
+                                        sensors,
+                                        true);
+                        if(!infoFound)
+                        {
+                                UWARN("Failed to get node info for pose %d when exporting camera positions.", iter->first);
+                        }
+                        cameraStamps.insert(std::make_pair(iter->first, stamp));
+                }
+
                 if(cameraStamps.size() != cameraPoses.size())
                 {
                         UWARN("Skipping camera position export because %d pose stamps were found for %d poses.", (int)cameraStamps.size(), (int)cameraPoses.size());
                 }
-                else
+                else if(!cameraPoses.empty())
                 {
                         std::string jsonPath = directory + UDirectory::separator() + name + ".json";
                         if(rtabmap::graph::exportPoses(jsonPath, 12, cameraPoses, std::multimap<int, rtabmap::Link>(), cameraStamps, rtabmap_->getParameters()))

--- a/app/android/jni/RTABMapApp.cpp
+++ b/app/android/jni/RTABMapApp.cpp
@@ -49,6 +49,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/core/util3d_filtering.h>
 #include <rtabmap/core/util3d_surface.h>
 #include <rtabmap/core/Graph.h>
+#include <rtabmap/core/Link.h>
 #include <rtabmap/utilite/UEventsManager.h>
 #include <rtabmap/utilite/UStl.h>
 #include <rtabmap/utilite/UDirectory.h>
@@ -3378,7 +3379,48 @@ bool RTABMapApp::exportMesh(
 
 	exporting_ = true;
 
-	bool success = false;
+        bool success = false;
+
+        std::map<int, rtabmap::Transform> cameraPoses;
+        std::map<int, double> cameraStamps;
+        if(rtabmap_ && rtabmap_->getMemory())
+        {
+                std::map<int, rtabmap::Transform> poses = rtabmap_->getLocalOptimizedPoses();
+                if(poses.empty())
+                {
+                        std::multimap<int, rtabmap::Link> tmpLinks;
+                        rtabmap_->getGraph(poses, tmpLinks, true, true);
+                }
+                for(std::map<int, rtabmap::Transform>::const_iterator iter=poses.lower_bound(0); iter!=poses.end(); ++iter)
+                {
+                        cameraPoses.insert(*iter);
+                        rtabmap::Transform odomPose, groundTruth;
+                        int mapId = 0;
+                        int weight = 0;
+                        std::string label;
+                        double stamp = 0.0;
+                        std::vector<float> velocity;
+                        rtabmap::GPS gps;
+                        rtabmap::EnvSensors sensors;
+                        bool infoFound = rtabmap_->getMemory()->getNodeInfo(
+                                        iter->first,
+                                        odomPose,
+                                        mapId,
+                                        weight,
+                                        label,
+                                        stamp,
+                                        groundTruth,
+                                        velocity,
+                                        gps,
+                                        sensors,
+                                        true);
+                        if(!infoFound)
+                        {
+                                UWARN("Failed to get node info for pose %d when exporting camera positions.", iter->first);
+                        }
+                        cameraStamps.insert(std::make_pair(iter->first, stamp));
+                }
+        }
 
 	try
 	{
@@ -4413,9 +4455,29 @@ bool RTABMapApp::writeExportedMesh(const std::string & directory, const std::str
 				UERROR("Failed saving obj to %s!", filePath.c_str());
 			}
 		}
-	}
-	exporting_ = false;
-	return success;
+        }
+
+        if(!cameraPoses.empty())
+        {
+                if(cameraStamps.size() != cameraPoses.size())
+                {
+                        UWARN("Skipping camera position export because %d pose stamps were found for %d poses.", (int)cameraStamps.size(), (int)cameraPoses.size());
+                }
+                else
+                {
+                        std::string jsonPath = directory + UDirectory::separator() + name + ".json";
+                        if(rtabmap::graph::exportPoses(jsonPath, 12, cameraPoses, std::multimap<int, rtabmap::Link>(), cameraStamps, rtabmap_->getParameters()))
+                        {
+                                LOGI("Saved camera positions to %s!", jsonPath.c_str());
+                        }
+                        else
+                        {
+                                UERROR("Failed saving camera positions to %s!", jsonPath.c_str());
+                        }
+                }
+        }
+        exporting_ = false;
+        return success;
 }
 
 int RTABMapApp::postProcessing(int approach)

--- a/app/android/jni/RTABMapApp.cpp
+++ b/app/android/jni/RTABMapApp.cpp
@@ -63,6 +63,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rtabmap/core/Optimizer.h>
 #include <rtabmap/core/VWDictionary.h>
 #include <rtabmap/core/Memory.h>
+#include <rtabmap/core/Signature.h>
 #include <rtabmap/core/GainCompensator.h>
 #include <rtabmap/core/DBDriver.h>
 #include <rtabmap/core/Recovery.h>
@@ -4428,7 +4429,6 @@ bool RTABMapApp::writeExportedMesh(const std::string & directory, const std::str
                 }
                 for(std::map<int, rtabmap::Transform>::const_iterator iter=stampedPoses.lower_bound(0); iter!=stampedPoses.end(); ++iter)
                 {
-                        cameraPoses.insert(*iter);
                         rtabmap::Transform odomPose, groundTruth;
                         int mapId = 0;
                         int weight = 0;
@@ -4453,14 +4453,27 @@ bool RTABMapApp::writeExportedMesh(const std::string & directory, const std::str
                         {
                                 UWARN("Failed to get node info for pose %d when exporting camera positions.", iter->first);
                         }
+
+                        if(stamp <= 0.0)
+                        {
+                                const rtabmap::Signature * signature = rtabmap_->getMemory()->getSignature(iter->first);
+                                if(signature)
+                                {
+                                        stamp = signature->getStamp();
+                                }
+                        }
+
+                        if(stamp <= 0.0)
+                        {
+                                UWARN("Skipping camera position %d because it has no valid timestamp.", iter->first);
+                                continue;
+                        }
+
+                        cameraPoses.insert(*iter);
                         cameraStamps.insert(std::make_pair(iter->first, stamp));
                 }
 
-                if(cameraStamps.size() != cameraPoses.size())
-                {
-                        UWARN("Skipping camera position export because %d pose stamps were found for %d poses.", (int)cameraStamps.size(), (int)cameraPoses.size());
-                }
-                else if(!cameraPoses.empty())
+                if(!cameraPoses.empty())
                 {
                         std::string jsonPath = directory + UDirectory::separator() + name + ".json";
                         if(rtabmap::graph::exportPoses(jsonPath, 12, cameraPoses, std::multimap<int, rtabmap::Link>(), cameraStamps, rtabmap_->getParameters()))

--- a/corelib/include/rtabmap/core/Graph.h
+++ b/corelib/include/rtabmap/core/Graph.h
@@ -47,11 +47,11 @@ namespace graph {
 ////////////////////////////////////////////
 
 bool RTABMAP_CORE_EXPORT exportPoses(
-		const std::string & filePath,
-		int format, // 0=Raw (*.txt), 1=RGBD-SLAM motion capture (*.txt) (10=without change of coordinate frame, 11=10+ID), 2=KITTI (*.txt), 3=TORO (*.graph), 4=g2o (*.g2o)
+               const std::string & filePath,
+               int format, // 0=Raw (*.txt), 1=RGBD-SLAM motion capture (*.txt) (10=without change of coordinate frame, 11=10+ID), 2=KITTI (*.txt), 3=TORO (*.graph), 4=g2o (*.g2o), 12=JSON (*.json)
 		const std::map<int, Transform> & poses,
 		const std::multimap<int, Link> & constraints = std::multimap<int, Link>(), // required for formats 3 and 4
-		const std::map<int, double> & stamps = std::map<int, double>(),  // required for format 1
+               const std::map<int, double> & stamps = std::map<int, double>(),  // required for formats 1, 10, 11 and 12
 		const ParametersMap & parameters = ParametersMap()); // optional for formats 3 and 4
 
 bool RTABMAP_CORE_EXPORT importPoses(

--- a/corelib/src/Graph.cpp
+++ b/corelib/src/Graph.cpp
@@ -47,6 +47,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iomanip>
 #include <cmath>
 #include <ctime>
+#include <locale>
 
 #include <rtabmap/core/optimizer/OptimizerTORO.h>
 #include <rtabmap/core/optimizer/OptimizerG2O.h>
@@ -156,17 +157,14 @@ bool exportPoses(
                                 return false;
                         }
 
-                        FILE * fout = 0;
-#ifdef _MSC_VER
-                        fopen_s(&fout, tmpPath.c_str(), "w");
-#else
-                        fout = fopen(tmpPath.c_str(), "w");
-#endif
-                        if(!fout)
+                        std::ofstream fout(tmpPath.c_str(), std::ios::out | std::ios::trunc);
+                        if(!fout.is_open())
                         {
                                 UERROR("Could not open file %s for writing.", tmpPath.c_str());
                                 return false;
                         }
+
+                        fout.imbue(std::locale::classic());
 
                         std::list<std::pair<int, Transform> > posesList;
                         for(std::map<int, Transform>::const_iterator iter=poses.lower_bound(0); iter!=poses.end(); ++iter)
@@ -174,37 +172,39 @@ bool exportPoses(
                                 posesList.push_back(*iter);
                         }
 
-                        fprintf(fout, "{\n  \"cameraPositions\": {");
+                        fout << "{\n  \"cameraPositions\": {";
 
-                        bool firstEntry = true;
-                        for(std::list<std::pair<int, Transform> >::const_iterator iter=posesList.begin(); iter!=posesList.end(); ++iter)
+                        if(!posesList.empty())
                         {
-                                UASSERT(uContains(stamps, iter->first));
-                                if(!firstEntry)
+                                fout.setf(std::ios::fixed, std::ios::floatfield);
+                                fout << std::setprecision(6);
+                                bool firstEntry = true;
+                                for(std::list<std::pair<int, Transform> >::const_iterator iter=posesList.begin(); iter!=posesList.end(); ++iter)
                                 {
-                                        fprintf(fout, ",");
+                                        UASSERT(uContains(stamps, iter->first));
+                                        if(!firstEntry)
+                                        {
+                                                fout << ",\n";
+                                        }
+                                        else
+                                        {
+                                                fout << "\n";
+                                                firstEntry = false;
+                                        }
+                                        const std::string stamp = stampToUtcString(stamps.at(iter->first));
+                                        fout << "    \"" << stamp << "\": {\"positionX\": " << iter->second.x()
+                                             << ", \"positionY\": " << iter->second.y()
+                                             << ", \"positionZ\": " << iter->second.z() << "}";
                                 }
-                                std::string stamp = stampToUtcString(stamps.at(iter->first));
-                                fprintf(fout,
-                                                "\n    \"%s\": {\"positionX\": %.6f, \"positionY\": %.6f, \"positionZ\": %.6f}",
-                                                stamp.c_str(),
-                                                iter->second.x(),
-                                                iter->second.y(),
-                                                iter->second.z());
-                                firstEntry = false;
-                        }
-
-                        if(firstEntry)
-                        {
-                                fprintf(fout, "}");
+                                fout << "\n  }\n}\n";
                         }
                         else
                         {
-                                fprintf(fout, "\n  }");
+                                fout << "}\n}\n";
                         }
-                        fprintf(fout, "\n}\n");
-                        fclose(fout);
-                        return true;
+
+                        fout.close();
+                        return fout.good();
                 }
 
                 FILE* fout = 0;

--- a/corelib/src/Graph.cpp
+++ b/corelib/src/Graph.cpp
@@ -43,6 +43,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <set>
 #include <queue>
 #include <fstream>
+#include <sstream>
+#include <iomanip>
+#include <cmath>
+#include <ctime>
 
 #include <rtabmap/core/optimizer/OptimizerTORO.h>
 #include <rtabmap/core/optimizer/OptimizerG2O.h>
@@ -51,12 +55,52 @@ namespace rtabmap {
 
 namespace graph {
 
+namespace {
+
+std::string stampToUtcString(double stamp)
+{
+        double secondsDouble = std::floor(stamp);
+        double fractional = stamp - secondsDouble;
+        if(fractional < 0.0)
+        {
+                fractional += 1.0;
+                secondsDouble -= 1.0;
+        }
+
+        std::time_t rawTime = static_cast<std::time_t>(secondsDouble);
+        int milliseconds = static_cast<int>(uRound(fractional * 1000.0));
+        if(milliseconds >= 1000)
+        {
+                milliseconds -= 1000;
+                ++rawTime;
+        }
+
+        std::tm tmStruct;
+#ifdef _MSC_VER
+        gmtime_s(&tmStruct, &rawTime);
+#else
+        gmtime_r(&rawTime, &tmStruct);
+#endif
+
+        char timeBuffer[32];
+        if(std::strftime(timeBuffer, sizeof(timeBuffer), "%Y-%m-%dT%H:%M:%S", &tmStruct) == 0)
+        {
+                return uNumber2Str(stamp);
+        }
+
+        std::ostringstream oss;
+        oss << timeBuffer << "." << std::setw(3) << std::setfill('0') << milliseconds << "Z";
+        return oss.str();
+}
+
+} // namespace
+
 bool exportPoses(
 		const std::string & filePath,
 		int format, // 0=Raw, 1=RGBD-SLAM motion capture (10=without change of coordinate frame, 11=10+ID), 2=KITTI, 3=TORO, 4=g2o
 		const std::map<int, Transform> & poses,
-		const std::multimap<int, Link> & constraints, // required for formats 3 and 4
-		const std::map<int, double> & stamps, // required for format 1, 10 and 11
+               const std::multimap<int, Link> & constraints, // required for formats 3 and 4
+               const std::map<int, double> & stamps, // required for formats 1, 10, 11 and 12
 		const ParametersMap & parameters) // optional for formats 3 and 4
 {
 	UDEBUG("%s", filePath.c_str());
@@ -79,26 +123,86 @@ bool exportPoses(
 		OptimizerG2O g2o(parameters);
 		return g2o.saveGraph(tmpPath, poses, constraints);
 	}
-	else
-	{
-		if(UFile::getExtension(tmpPath).empty())
-		{
-			tmpPath+=".txt";
-		}
+        else
+        {
+                if(UFile::getExtension(tmpPath).empty())
+                {
+                        if(format == 12)
+                        {
+                                tmpPath+=".json";
+                        }
+                        else
+                        {
+                                tmpPath+=".txt";
+                        }
+                }
 
-		if(format == 1 || format == 10 || format == 11)
-		{
-			if(stamps.size() != poses.size())
-			{
+                if(format == 1 || format == 10 || format == 11)
+                {
+                        if(stamps.size() != poses.size())
+                        {
 				UERROR("When exporting poses to format 1 (RGBD-SLAM), stamps and poses maps should have the same size! stamps=%d poses=%d",
 						(int)stamps.size(), (int)poses.size());
 				return false;
 			}
 		}
 
-		FILE* fout = 0;
+                if(format == 12)
+                {
+                        if(stamps.size() != poses.size())
+                        {
+                                UERROR("When exporting poses to format 12 (JSON), stamps and poses maps should have the same size! stamps=%d poses=%d",
+                                                (int)stamps.size(), (int)poses.size());
+                                return false;
+                        }
+
+                        std::ofstream fout(tmpPath.c_str());
+                        if(!fout.good())
+                        {
+                                UERROR("Could not open file %s for writing.", tmpPath.c_str());
+                                return false;
+                        }
+
+                        std::list<std::pair<int, Transform> > posesList;
+                        for(std::map<int, Transform>::const_iterator iter=poses.lower_bound(0); iter!=poses.end(); ++iter)
+                        {
+                                posesList.push_back(*iter);
+                        }
+
+                        fout << "{\n  \"cameraPositions\": {";
+                        fout << std::setprecision(6) << std::fixed;
+
+                        bool firstEntry = true;
+                        for(std::list<std::pair<int, Transform> >::const_iterator iter=posesList.begin(); iter!=posesList.end(); ++iter)
+                        {
+                                UASSERT(uContains(stamps, iter->first));
+                                if(!firstEntry)
+                                {
+                                        fout << ",";
+                                }
+                                fout << "\n    \"" << stampToUtcString(stamps.at(iter->first)) << "\": {";
+                                fout << "\"positionX\": " << iter->second.x() << ", ";
+                                fout << "\"positionY\": " << iter->second.y() << ", ";
+                                fout << "\"positionZ\": " << iter->second.z() << "}";
+                                firstEntry = false;
+                        }
+
+                        if(firstEntry)
+                        {
+                                fout << "}";
+                        }
+                        else
+                        {
+                                fout << "\n  }";
+                        }
+                        fout << "\n}\n";
+                        fout.close();
+                        return true;
+                }
+
+                FILE* fout = 0;
 #ifdef _MSC_VER
-		fopen_s(&fout, tmpPath.c_str(), "w");
+                fopen_s(&fout, tmpPath.c_str(), "w");
 #else
 		fout = fopen(tmpPath.c_str(), "w");
 #endif

--- a/corelib/src/Graph.cpp
+++ b/corelib/src/Graph.cpp
@@ -156,8 +156,13 @@ bool exportPoses(
                                 return false;
                         }
 
-                        std::ofstream fout(tmpPath.c_str());
-                        if(!fout.good())
+                        FILE * fout = 0;
+#ifdef _MSC_VER
+                        fopen_s(&fout, tmpPath.c_str(), "w");
+#else
+                        fout = fopen(tmpPath.c_str(), "w");
+#endif
+                        if(!fout)
                         {
                                 UERROR("Could not open file %s for writing.", tmpPath.c_str());
                                 return false;
@@ -169,8 +174,7 @@ bool exportPoses(
                                 posesList.push_back(*iter);
                         }
 
-                        fout << "{\n  \"cameraPositions\": {";
-                        fout << std::setprecision(6) << std::fixed;
+                        fprintf(fout, "{\n  \"cameraPositions\": {");
 
                         bool firstEntry = true;
                         for(std::list<std::pair<int, Transform> >::const_iterator iter=posesList.begin(); iter!=posesList.end(); ++iter)
@@ -178,25 +182,28 @@ bool exportPoses(
                                 UASSERT(uContains(stamps, iter->first));
                                 if(!firstEntry)
                                 {
-                                        fout << ",";
+                                        fprintf(fout, ",");
                                 }
-                                fout << "\n    \"" << stampToUtcString(stamps.at(iter->first)) << "\": {";
-                                fout << "\"positionX\": " << iter->second.x() << ", ";
-                                fout << "\"positionY\": " << iter->second.y() << ", ";
-                                fout << "\"positionZ\": " << iter->second.z() << "}";
+                                std::string stamp = stampToUtcString(stamps.at(iter->first));
+                                fprintf(fout,
+                                                "\n    \"%s\": {\"positionX\": %.6f, \"positionY\": %.6f, \"positionZ\": %.6f}",
+                                                stamp.c_str(),
+                                                iter->second.x(),
+                                                iter->second.y(),
+                                                iter->second.z());
                                 firstEntry = false;
                         }
 
                         if(firstEntry)
                         {
-                                fout << "}";
+                                fprintf(fout, "}");
                         }
                         else
                         {
-                                fout << "\n  }";
+                                fprintf(fout, "\n  }");
                         }
-                        fout << "\n}\n";
-                        fout.close();
+                        fprintf(fout, "\n}\n");
+                        fclose(fout);
                         return true;
                 }
 

--- a/corelib/src/Rtabmap.cpp
+++ b/corelib/src/Rtabmap.cpp
@@ -1072,7 +1072,7 @@ void Rtabmap::exportPoses(const std::string & path, bool optimized, bool global,
 		}
 
 		std::map<int, double> stamps;
-		if(format == 1 || format == 10 || format == 11)
+		if(format == 1 || format == 10 || format == 11 || format == 12)
 		{
 			for(std::map<int, Transform>::iterator iter=poses.begin(); iter!=poses.end(); ++iter)
 			{

--- a/tools/Export/main.cpp
+++ b/tools/Export/main.cpp
@@ -117,7 +117,8 @@ void showUsage()
 			"                              1=RGBD-SLAM (in motion capture coordinate frame)\n"
 			"                              2=KITTI (same as raw but in optical frame)\n"
 			"                              3=TORO\n"
-			"                              4=g2o\n"
+                       "                              4=g2o\n"
+                       "                              12=JSON (UTC stamp to XYZ)\n"
 			"                              10=RGBD-SLAM in ROS coordinate frame (stamp x y z qx qy qz qw)\n"
 			"                              11=RGBD-SLAM in ROS coordinate frame + ID (stamp x y z qx qy qz qw id)\n"
 			"    --gps #               Export GPS values of the GPS frame in world coordinates. Formats:\n"
@@ -1804,7 +1805,7 @@ int main(int argc, char * argv[])
 	}
 	else
 	{
-		std::string posesExt = (exportPosesFormat==3?"toro":exportPosesFormat==4?"g2o":"txt");
+		std::string posesExt = (exportPosesFormat==3?"toro":exportPosesFormat==4?"g2o":exportPosesFormat==12?"json":"txt");
 		if(exportPoses)
 		{
 			std::string outputPath=outputDirectory+"/"+baseName+"_poses." + posesExt;


### PR DESCRIPTION
## Summary
- include the JSON pose export format in the public graph API comments and tooling defaults
- make the mobile mesh export gather stamped camera poses and drop a JSON file beside the OBJ assets
- allow the core pose exporter to fetch stamps when format 12 is requested

## Testing
- cmake --build build *(fails: could not load cache)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1d72f1d08321b34732f96472fbcc